### PR TITLE
fix bug when SMTP account is specified and there is a : in the blog name

### DIFF
--- a/_public.php
+++ b/_public.php
@@ -143,7 +143,7 @@ class urlContactMe extends dcUrlHandlers
                 }
 
                 if ($core->blog->settings->contactme->cm_smtp_account) {
-                    $from = mail::B64Header($core->blog->name) . ' <' . $core->blog->settings->contactme->cm_smtp_account . '>';
+                    $from = mail::B64Header(str_replace(':', '-', $core->blog->name)) . ' <' . $core->blog->settings->contactme->cm_smtp_account . '>';
                 } else {
                     $from = mail::B64Header($_ctx->contactme['name']) . ' <' . $_ctx->contactme['email'] . '>';
                 }


### PR DESCRIPTION
When the SMTP account is specified in the settings, the sender of the email will be "blog name" <smtp_account>.
But if there is a : in the blog name, this will break the headers, as the : is the character used in headers to separate keys and values.
I propose a simple fix here, but maybe the function mail::B64Header should take care of this cleaning.